### PR TITLE
Pin build system poetry-core to the latest 1.9 version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core==1.9.1"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry-core==1.9.1"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]


### PR DESCRIPTION
Poetry-core released a 2.0 version on January 4th: https://pypi.org/project/poetry-core/#history

This causes incompatibilities when building this package from the wheel. Hopefully pinning the build system poetry core version will fix this!

```
  • Installing onnx-clip (4.0.1 4cdc1c5)
  ChefBuildError
  Backend subprocess exited when trying to invoke build_wheel
  
  Traceback (most recent call last):
    File "/opt/hostedtoolcache/Python/3.9.21/x64/lib/python3.9/site-packages/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
      main()
    File "/opt/hostedtoolcache/Python/3.9.21/x64/lib/python3.9/site-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in main
      json_out["return_val"] = hook(**hook_input["kwargs"])
    File "/opt/hostedtoolcache/Python/3.9.21/x64/lib/python3.9/site-packages/pyproject_hooks/_in_process/_in_process.py", line 280, in build_wheel
      return _build_backend().build_wheel(
    File "/tmp/tmphsrpo2xg/.venv/lib/python3.9/site-packages/poetry/core/masonry/api.py", line 55, in build_wheel
      poetry = Factory().create_poetry(Path().resolve(), with_groups=False)
    File "/tmp/tmphsrpo2xg/.venv/lib/python3.9/site-packages/poetry/core/factory.py", line 58, in create_poetry
      raise RuntimeError("The Poetry configuration is invalid:\n" + message)
  RuntimeError: The Poetry configuration is invalid:
    - project must contain ['name'] properties
```